### PR TITLE
Add functionality to check if clang-format-#.#\+ is on the path

### DIFF
--- a/stylize/__main__.py
+++ b/stylize/__main__.py
@@ -57,6 +57,9 @@ def main():
 
     # register any formatter-specific arguments
     for formatter in formatters:
+        if formatter.get_command() == None:
+            print("[ERR] A required dependency was not found. Check to see if clang-format is available on your path.")
+            exit(1)
         formatter.add_args(parser)
 
     # map file extension to formatter

--- a/stylize/clang_formatter.py
+++ b/stylize/clang_formatter.py
@@ -3,10 +3,11 @@ from stylize.util import file_md5
 
 import os
 import subprocess
-
+import shutil
 
 class ClangFormatter(Formatter):
     def __init__(self):
+        self.clang_command = self.get_command()
         self.file_extensions = [".c", ".h", ".cpp", ".hpp"]
 
     def add_args(self, argparser):
@@ -22,11 +23,11 @@ class ClangFormatter(Formatter):
         if check:
             style_arg = "-style=%s" % args.clang_style if args.clang_style != None else ""
             return os.system(
-                "clang-format %s -output-replacements-xml %s | grep '<replacement ' > /dev/null 2>&1"
+                self.clang_command + " %s -output-replacements-xml %s | grep '<replacement ' > /dev/null 2>&1"
                 % (style_arg, filepath)) == 0
         else:
             md5_before = file_md5(filepath)
-            popen_args = ["clang-format", "-i"]
+            popen_args = [self.clang_command, "-i"]
             if args.clang_style:
                 popen_args.append("-style=%s" % args.clang_style)
             popen_args.append(filepath)
@@ -34,3 +35,14 @@ class ClangFormatter(Formatter):
             proc.communicate()
             md5_after = file_md5(filepath)
             return md5_before != md5_after
+
+    def get_command(self):
+        if shutil.which("clang-format") != None:
+            return "clang-format"
+        # Run the next command in bash, as we need the bash builtin, compgen
+        possible_command = subprocess.Popen(["bash", "-c", "compgen -A function -abck | grep -E clang-format-[0-9]+\.[0-9]+ | tail -n 1"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout.read().decode("utf-8").strip()
+        if possible_command != "":
+            return possible_command
+        else:
+            return None

--- a/stylize/formatter.py
+++ b/stylize/formatter.py
@@ -15,6 +15,11 @@ class Formatter:
     def run(self, args, filepath, check=False):
         raise NotImplementedError("Subclass of Formatter must override run()")
 
+    ## Checks if requirements are fullfilled and returns the command to use if they are
+    # @return None if the required command is not found and the command to use by this formatter if found.
+    def get_command(self):
+        return None
+
     ## A list of file extensions that this formatter is relevant for.  Included
     # the dot.
     @property

--- a/stylize/yapf_formatter.py
+++ b/stylize/yapf_formatter.py
@@ -2,6 +2,7 @@ from stylize.formatter import Formatter
 from stylize.util import file_md5
 
 import subprocess
+import shutil
 
 
 class YapfFormatter(Formatter):
@@ -24,3 +25,6 @@ class YapfFormatter(Formatter):
             proc.communicate()
             md5_after = file_md5(filepath)
             return md5_before != md5_after
+
+    def get_command(self):
+        return shutil.which("yapf")


### PR DESCRIPTION
Fixes the issue we saw in [robojackets/robocup-software](https://github.com/RoboJackets/robocup-software/pull/382) #382.

Now stylize will check the path for commands that match the extended regex `clang-format-[0-9]+\.[0-9]+` and use a command that is found if one is. If one is not found, it will print an error message and exit. (The command returned in this case is `false`, so anything run should fail).

Let me know if I structured this stupidly... :confused: 
