### PR TITLE
Fix error when --diffbase is not valid

### DIFF
--- a/stylize/__main__.py
+++ b/stylize/__main__.py
@@ -36,17 +36,18 @@ def enumerate_changed_files(exclude=[], diffbase="origin/master"):
     try:
         # try to find common ancestor between @diffbase and @current_commit
         ancestor = subprocess.check_output(
-            ['git', 'merge-base', current_git_commit(), diffbase]).strip().decode(
-                'utf-8')
+            ['git', 'merge-base', current_git_commit(), diffbase]).strip(
+            ).decode('utf-8')
     except subprocess.CalledProcessError:
         # There was no common ancestor between @diffbase and @current_commit
         ancestor = subprocess.check_output(
-            ['git', 'rev-list', '--max-parents=0',
-             current_git_commit()]).strip().decode('utf-8')
-        print("[ERR] Your diffbase: '" + str(diffbase)
-              + "' does not share a common ancestor with '"
-              + str(current_git_commit()) + "'. "
-              + "Using '" + str(ancestor) + "' instead.", file=sys.stderr)
+            ['git', 'rev-list', '--max-parents=0', current_git_commit()
+             ]).strip().decode('utf-8')
+        print("[ERR] Your diffbase: '" + str(diffbase) +
+              "' does not share a common ancestor with '" +
+              str(current_git_commit()) + "'. " + "Using '" + str(ancestor) +
+              "' instead.",
+              file=sys.stderr)
 
     # get list of files that have changed since @ancestor.
     out = subprocess.check_output([

--- a/stylize/__main__.py
+++ b/stylize/__main__.py
@@ -40,7 +40,7 @@ def enumerate_changed_files(exclude=[], diffbase="origin/master"):
             ).decode('utf-8')
     except subprocess.CalledProcessError:
         # There was no common ancestor between @diffbase and @current_commit
-        return []
+        return None
 
     # get list of files that have changed since @ancestor.
     out = subprocess.check_output([
@@ -122,8 +122,8 @@ def main():
         # list to format/checkstyle.
 
         print("%s files that differ from %s..." % (verb, ARGS.diffbase))
-        changed_files = list(enumerate_changed_files(ARGS.exclude_dirs,
-                                                     ARGS.diffbase))
+        changed_files = enumerate_changed_files(ARGS.exclude_dirs,
+                                                ARGS.diffbase)
         if not changed_files:
             # We were unable to find a proper diffbase
             print("[ERR] Your diffbase does not share a common ancestor with '"
@@ -134,6 +134,7 @@ def main():
             print("%s all c++ and python files in the project..." % verb)
             files_to_format = enumerate_all_files(ARGS.exclude_dirs)
         else:
+            changed_files = list(changed_files)
             files_to_format = changed_files
 
             # Build a set of file extensions for which the config file has been modified.

--- a/stylize/__main__.py
+++ b/stylize/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from stylize.util import print_aligned, file_ext
 from stylize.clang_formatter import ClangFormatter
 from stylize.yapf_formatter import YapfFormatter
@@ -32,10 +33,20 @@ def current_git_commit():
 ## Yields all files that differ from the branching point with @diffbase or are
 # not tracked by git.
 def enumerate_changed_files(exclude=[], diffbase="origin/master"):
-    # find common ancestor between @diffbase and @current_commit
-    ancestor = subprocess.check_output(
-        ['git', 'merge-base', current_git_commit(), diffbase]).strip().decode(
-            'utf-8')
+    try:
+        # try to find common ancestor between @diffbase and @current_commit
+        ancestor = subprocess.check_output(
+            ['git', 'merge-base', current_git_commit(), diffbase]).strip().decode(
+                'utf-8')
+    except subprocess.CalledProcessError:
+        # There was no common ancestor between @diffbase and @current_commit
+        ancestor = subprocess.check_output(
+            ['git', 'rev-list', '--max-parents=0',
+             current_git_commit()]).strip().decode('utf-8')
+        print("[ERR] Your diffbase: '" + str(diffbase)
+              + "' does not share a common ancestor with '"
+              + str(current_git_commit()) + "'. "
+              + "Using '" + str(ancestor) + "' instead.", file=sys.stderr)
 
     # get list of files that have changed since @ancestor.
     out = subprocess.check_output([


### PR DESCRIPTION
When --diffbase is not a valid ancestor of the current commit, there
used to be an exception. Now stylize will print an error message, and
use the earliest commit as it's diffbase (effectively style checking the
entire repo for the first time).

Fixes #22
