### PR TITLE
Allow users of stylize to select version of yapf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = false
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[{package.json,*.yml}]
+indent_style = space
+indent_size = 2
+

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(name='stylize',
                    'Programming Language :: Python :: 3.4',
                    'Topic :: Software Development :: Quality Assurance', ],
       entry_points={'console_scripts': ['stylize = stylize.__main__:main'], },
-      install_requires=['yapf==0.6.0'],
+      install_requires=['yapf'],
       test_suite='nose.collector',
       tests_require=['nose', 'coverage'], )


### PR DESCRIPTION
Per https://github.com/RoboJackets/robocup-software/issues/1009, we would like to select our own yapf version. 

However, stylize has a hard requires on an older version of yapf, so this is not possible.

This PR allows any version of yapf to be used (and let users pin the version of yapf, rather than stylize). 

I can add a note to the README reccomending pinning yapf if you would like!